### PR TITLE
[WIP] Add proof-of-concept PoolByteArray support

### DIFF
--- a/src/foreignlibrary.cpp
+++ b/src/foreignlibrary.cpp
@@ -133,6 +133,7 @@ Variant ForeignLibrary::invoke(String method, Array args) {
     // TODO: Suport more arg types
     String str;
     char* pStr;
+    PoolByteArray pba;
     for (int i = 0; i < args.size(); i++) {
         switch(args[i].get_type()) {
             case Variant::Type::NIL:
@@ -155,6 +156,13 @@ Variant ForeignLibrary::invoke(String method, Array args) {
                 pStr[str.length()] = 0;
                 arg_values[i] = new char*(pStr);
                 break;
+            case Variant::Type::POOL_BYTE_ARRAY:
+                // Mostly copy pasta from STRING case above.
+                pba = args[i];
+                pStr = new char[pba.size()];
+                memcpy(pStr, pba.read().ptr(), pba.size());
+                arg_values[i] = new char*(pStr); // TODO: Figure out if Ref and/or pba.write().ptr() helpful.
+                break;
             default:
                 // Variant::___get_type_name(args[i].get_type())
                 Godot::print_error(
@@ -174,6 +182,7 @@ Variant ForeignLibrary::invoke(String method, Array args) {
     // Release memory of allocated variables
     for (int i = 0; i < signature->cif->nargs; i++) {
         // TODO: Fix this
+        // TODO: Also handle PoolByteArray here.
         if (signature->argtypes[i] == "string") {
             delete (char*)(*(char**)arg_values[i]);
         } else {

--- a/test/test.gd
+++ b/test/test.gd
@@ -71,6 +71,13 @@ func _init():
     print(result)
     ASSERT(result == 'Foobar')
 
+    print('##### PoolByteArray')
+
+    print('* Testing char* joinStrings(char*, PoolByteArray)')
+    result = lib.invoke('joinStrings', ['Foo', PoolByteArray([0x41, 0x00])])
+    print(result)
+    ASSERT(result == 'FooA')
+
     print('Testing finished')
     quit()
 


### PR DESCRIPTION
Add support for arguments of type [`PoolByteArray`](https://docs.godotengine.org/en/3.2/classes/class_poolbytearray.html)--this enables passing sequences of arbitrary bytes (including `0x00` which is not possible via the existing string support) as function arguments.

This implementation is primarily based on the existing String approach--so there may be approaches better suited to the specifics of how `PoolByteArray` is implemented.

Note: Currently there is no cleanup of the created objects, so this will leak memory.

Tracked by #2