### PR TITLE
Fix file path to testlib.so so it is found.

### DIFF
--- a/test/test.gd
+++ b/test/test.gd
@@ -12,7 +12,7 @@ func _init():
     ASSERT(foreigner)
     prints('Foreigner:', foreigner)
 
-    var lib = foreigner.open('testlib.so')
+    var lib = foreigner.open('./testlib.so')
     ASSERT(lib)
     print('Library:', lib)
 


### PR DESCRIPTION
Apparently to be found in a relative directory the path needs to
start with "./" otherwise system paths are searched by dlopen.

(Based on Godot source comment: <https://github.com/godotengine/godot/blob/b7b39786840a41a057f531ed13b64e26366befac/drivers/unix/os_unix.cpp#L404-L408>.)

Note: This may create issues on other platforms and/or on export?