### PR TITLE
Make library path relative to match test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Lastly, use it in Godot as follows:
 # as char* and const char*.
 
 var foreigner = preload('res://contrib/foreigner/foreigner.gdns').new()
-var library = foreigner.open('testlib.so')
+var library = foreigner.open('./testlib.so')
 
 library.define('getNumber', 'sint32', [])
 print(library.invoke('getNumber'))  # prints 42
@@ -63,7 +63,7 @@ print(library.invoke('joinStrings', ['Foo', 'bar']))  # Prints Foobar
 # Steam example
 
 var foreigner = preload('res://contrib/foreigner/foreigner.gdns').new()
-var library = foreigner.open('libsteam_api.so')
+var library = foreigner.open('./libsteam_api.so')
 
 library.define('SteamAPI_Init', 'void', [])
 prints(library.invoke('SteamAPI_Init'))


### PR DESCRIPTION
As mentioned in https://github.com/and3rson/foreigner/pull/5 without the `./` prefix the library is searched for via system paths rather than being treated as a relative directory reference.