### PR TITLE
Improve cross platform build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ ifeq ($(UNAME),Darwin)
 	CXX := clang++
 	LIB_SUFFIX := dylib
 	EXTRA_FLAGS := -Og
+	EXTRA_LIBS :=
 else
 	PLATFORM := linux
 	CXX := g++
 	LIB_SUFFIX := so
 	EXTRA_FLAGS :=
+	EXTRA_LIBS := -lstdc++ -static-libstdc++ -static-libgcc
 endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
@@ -27,7 +29,7 @@ INCLUDES= \
 		  -L$(GODOTCPP_PATH)/bin \
 		  $(FFI_INCLUDES)
 
-LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
+LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lffi $(EXTRA_LIBS)
 FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 
 all: $(FOREIGNER_LIB)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ INCLUDES= \
 		  -L$(GODOTCPP_PATH)/bin \
 		  $(FFI_INCLUDES)
 
-LIBS = -lgodot-cpp.linux.debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
+LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
 FLAGS = -ggdb -fPIC
 
 all: $(FOREIGNER_LIB)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Yup, I have them riiight there.
 GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
-GODOT_BINARY = $(GODOT_PATH)/bin/godot.x11.tools.64
+GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
 FFI_INCLUDES = $(shell pkg-config --cflags libffi)
 INCLUDES= \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
-FFI_INCLUDES = $(shell pkg-config --cflags libffi)
+FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \
 		  -I$(GODOTCPP_PATH)/include \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GODOT_BINARY = $(GODOT_PATH)/bin/godot.x11.tools.64
 
 FFI_INCLUDES = $(shell pkg-config --cflags libffi)
 INCLUDES= \
-		  -I$(GODOT_PATH)/modules/gdnative/include \
+		  -I$(GODOTCPP_PATH)/godot_headers \
 		  -I$(GODOTCPP_PATH)/include \
 		  -I$(GODOTCPP_PATH)/include/core \
 		  -I$(GODOTCPP_PATH)/include/gen \

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ FLAGS = -ggdb -fPIC
 all: foreigner.so
 
 foreigner.so: src/*.cpp src/*.h
-	gcc -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
+	$(CXX) -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
-	gcc -shared testlib/*.cpp -o testlib.so
+	$(CXX) -shared testlib/*.cpp -o testlib.so
 
 test: foreigner.so testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+	PLATFORM := osx
+	CXX := clang++
+	LIB_SUFFIX := dylib
+else
+	PLATFORM := linux
+	CXX := g++
+	LIB_SUFFIX := so
+endif
+
+FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
+
 FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ INCLUDES= \
 LIBS = -lgodot-cpp.linux.debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
 FLAGS = -ggdb -fPIC
 
-all: foreigner.so
+all: $(FOREIGNER_LIB)
 
-foreigner.so: src/*.cpp src/*.h
-	$(CXX) -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
+$(FOREIGNER_LIB): src/*.cpp src/*.h
+	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
 	$(CXX) -shared testlib/*.cpp -o testlib.so
 
-test: foreigner.so testlib.so
+test: $(FOREIGNER_LIB) testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ ifeq ($(UNAME),Darwin)
 	PLATFORM := osx
 	CXX := clang++
 	LIB_SUFFIX := dylib
+	EXTRA_FLAGS := -Og
 else
 	PLATFORM := linux
 	CXX := g++
 	LIB_SUFFIX := so
+	EXTRA_FLAGS :=
 endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
@@ -26,7 +28,7 @@ INCLUDES= \
 		  $(FFI_INCLUDES)
 
 LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
-FLAGS = -ggdb -fPIC
+FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 
 all: $(FOREIGNER_LIB)
 
@@ -34,7 +36,7 @@ $(FOREIGNER_LIB): src/*.cpp src/*.h
 	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
-	$(CXX) -shared testlib/*.cpp -o testlib.so
+	$(CXX) -shared testlib/*.cpp -o testlib.so $(EXTRA_FLAGS)
 
 test: $(FOREIGNER_LIB) testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd

--- a/foreigner.gdnlib
+++ b/foreigner.gdnlib
@@ -8,7 +8,9 @@ reloadable=true
 [entry]
 
 X11.64="res://foreigner.so"
+OSX.64="res://foreigner.dylib"
 
 [dependencies]
 
 X11.64=[  ]
+OSX.64=[  ]


### PR DESCRIPTION
Refactors & extends Makefile to enable building on Mac.

Not yet re-tested on Linux. Still need/plan to do that.

I've got the Foreigner test running successfully on a Mac but it requires 3.1 `godot-cpp` & some small `SConstruct` file edits due to a `Ref<>` bug in `godot-cpp` 3.2 (*Edit:* See https://github.com/and3rson/foreigner/issues/10) & older `SConstruct` file in the 3.1 branch. I hope to document this further later.

I considered moving from `Makefile` to `SConstruct` but figured (a) this would be less effort & (b) it would be better to discuss with you first. I suspect `scons` might make additional platform support easier in future though--given it's used to build `godot-cpp` itself. 

