### PR TITLE
Add build win64 on linux cross compile support + more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,42 @@
+#
+#
+## HOWTO: Cross-compiling for Win64 on Linux (Ubuntu/Elementary)
+#
+# Requires:
+#
+#  * Install cross-compilation tool chain:
+#
+#      sudo apt install g++-mingw-w64-x86-64
+#
+#  * Build the `godot-cpp` bindings to produce `libgodot-cpp.windows.debug.64.a`:
+#
+#      scons platform=windows bits=64 generate_bindings=yes -j4
+#
+#    (Cross-compilation is already supported in the
+#     `godot-cpp` scons configuration. I tested with
+#     Godot 3.1 branch @e4ad265339f17042a86227bfb44f9d5d7dee5ba4.)
+#
+# * Cross compile `libffi` from `libffi-3.3.tar.gz`:
+#
+#      ./configure --host x86_64-w64-mingw32
+#      make
+#      sudo make install # (semi-optional)
+#
+#  (Once I figured out *how* to configure the cross-
+#  compilation it was very straight-forward but it's
+#  not well documented.)
+#
+# * Use this `Makefile` to cross-compile `Foreigner`
+#   and produce `foreigner.dll`:
+#
+#      make CROSS_COMPILE_PLATFORM=win64
+#
+#   Additionally, if you have `wine64` & a
+#   Godot win64 executable you can test with:
+#
+#      make test CROSS_COMPILE_PLATFORM=win64 GODOT_BINARY="wine ~/<path>/Godot_v3.2.1-stable_win64.exe"
+#
+
 # Yup, I have them riiight there.
 GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
@@ -46,6 +85,14 @@ else ifeq ($(UNAME),Linux)
 		LIB_SUFFIX := so
 		EXTRA_FLAGS :=
 		EXTRA_LIBS := -static-libstdc++ -static-libgcc
+	else ifeq ($(CROSS_COMPILE_PLATFORM),win64)
+		PLATFORM := windows
+		BITS := 64
+		CXX := x86_64-w64-mingw32-g++
+		LIB_SUFFIX := dll
+		EXTRA_FLAGS := -std=c++11
+		EXTRA_LIBS := -static-libstdc++ -static-libgcc
+		PKG_CONFIG_ENV_VARS := PKG_CONFIG_LIBDIR=/usr/x86_64-w64-mingw32/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 PKG_CONFIG_ALLOW_SYSTEM_LIBS=1
 	else
 $(error Unrecognized cross compilation platform name.)
 	endif

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ ifeq ($(UNAME),Darwin)
 	CXX := clang++
 	LIB_SUFFIX := dylib
 	EXTRA_FLAGS := -Og
+	EXTRA_LIBS :=
 else
 	PLATFORM := linux
 	CXX := g++
 	LIB_SUFFIX := so
 	EXTRA_FLAGS :=
+	EXTRA_LIBS := -lstdc++ -static-libstdc++ -static-libgcc
 endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
@@ -27,7 +29,7 @@ INCLUDES= \
 		  -L$(GODOTCPP_PATH)/bin \
 		  $(FFI_INCLUDES)
 
-LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
+LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lffi $(EXTRA_LIBS)
 FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 
 all: $(FOREIGNER_LIB)

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ ifeq ($(UNAME),Darwin)
 	EXTRA_FLAGS := -Og
 	EXTRA_LIBS :=
 else ifeq ($(UNAME),Linux)
-	PLATFORM := linux
-	CXX := g++
-	LIB_SUFFIX := so
-	EXTRA_FLAGS :=
-	EXTRA_LIBS := -lstdc++ -static-libstdc++ -static-libgcc
+	ifeq ($(CROSS_COMPILE_PLATFORM),)
+		PLATFORM := linux
+		CXX := g++
+		LIB_SUFFIX := so
+		EXTRA_FLAGS :=
+		EXTRA_LIBS := -lstdc++ -static-libstdc++ -static-libgcc
+	else
+$(error Unrecognized cross compilation platform name.)
+	endif
 else
 $(error Unrecognized platform name.)
 endif
@@ -24,6 +28,7 @@ endif
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
 
 FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
+
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \
 		  -I$(GODOTCPP_PATH)/include \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ INCLUDES= \
 		  -L$(GODOTCPP_PATH)/bin \
 		  $(FFI_INCLUDES)
 
-LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lffi $(EXTRA_LIBS)
+LIBS = -lgodot-cpp.$(PLATFORM).debug.64 $(EXTRA_LIBS)
 FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 
 all: $(FOREIGNER_LIB)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ INCLUDES= \
 		  -L$(GODOTCPP_PATH)/bin \
 		  $(FFI_INCLUDES)
 
-LIBS = -lgodot-cpp.linux.debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
+LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
 FLAGS = -ggdb -fPIC
 
 all: $(FOREIGNER_LIB)

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ INCLUDES= \
 		  $(FFI_INCLUDES)
 
 LIBS = -lgodot-cpp.$(PLATFORM).debug.64 $(EXTRA_LIBS)
-FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
+FLAGS = -ggdb -fPIC $(EXTRA_FLAGS) -Wl,-static
 
 all: $(FOREIGNER_LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ INCLUDES= \
 		  $(FFI_INCLUDES)
 
 LIBS = -lgodot-cpp.$(PLATFORM).debug.64 $(EXTRA_LIBS)
-FLAGS = -ggdb -fPIC $(EXTRA_FLAGS) -Wl,-static
+FLAGS = -ggdb -fPIC $(EXTRA_FLAGS) -Wl,-static -Wall
 
 all: $(FOREIGNER_LIB)
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
 
-FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
+FFI_INCLUDES = $(shell $(PKG_CONFIG_ENV_VARS) pkg-config --static --cflags --libs  libffi)
 
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Yup, I have them riiight there.
 GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
-GODOT_BINARY = $(GODOT_PATH)/bin/godot.x11.tools.64
+GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
 FFI_INCLUDES = $(shell pkg-config --cflags libffi)
 INCLUDES= \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
-FFI_INCLUDES = $(shell pkg-config --cflags libffi)
+FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \
 		  -I$(GODOTCPP_PATH)/include \

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ all: $(FOREIGNER_LIB)
 $(FOREIGNER_LIB): src/*.cpp src/*.h
 	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
-testlib.so: testlib/*.cpp
-	$(CXX) -shared testlib/*.cpp -o testlib.so $(EXTRA_FLAGS)
+testlib.$(LIB_SUFFIX): testlib/*.cpp
+	$(CXX) -shared testlib/*.cpp -o testlib.$(LIB_SUFFIX) $(EXTRA_FLAGS) $(EXTRA_LIBS)
 
-test: $(FOREIGNER_LIB) testlib.so
+test: $(FOREIGNER_LIB) testlib.$(LIB_SUFFIX)
 	$(GODOT_BINARY) --no-window -s test/test.gd
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GODOT_BINARY = $(GODOT_PATH)/bin/godot.x11.tools.64
 
 FFI_INCLUDES = $(shell pkg-config --cflags libffi)
 INCLUDES= \
-		  -I$(GODOT_PATH)/modules/gdnative/include \
+		  -I$(GODOTCPP_PATH)/godot_headers \
 		  -I$(GODOTCPP_PATH)/include \
 		  -I$(GODOTCPP_PATH)/include/core \
 		  -I$(GODOTCPP_PATH)/include/gen \

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ FLAGS = -ggdb -fPIC
 all: foreigner.so
 
 foreigner.so: src/*.cpp src/*.h
-	gcc -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
+	$(CXX) -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
-	gcc -shared testlib/*.cpp -o testlib.so
+	$(CXX) -shared testlib/*.cpp -o testlib.so
 
 test: foreigner.so testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+	PLATFORM := osx
+	CXX := clang++
+	LIB_SUFFIX := dylib
+else
+	PLATFORM := linux
+	CXX := g++
+	LIB_SUFFIX := so
+endif
+
+FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
+
 FFI_INCLUDES = $(shell pkg-config --cflags --libs libffi)
 INCLUDES= \
 		  -I$(GODOTCPP_PATH)/godot_headers \

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ INCLUDES= \
 LIBS = -lgodot-cpp.linux.debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
 FLAGS = -ggdb -fPIC
 
-all: foreigner.so
+all: $(FOREIGNER_LIB)
 
-foreigner.so: src/*.cpp src/*.h
-	$(CXX) -shared src/*.cpp -o foreigner.so $(LIBS) $(INCLUDES) $(FLAGS)
+$(FOREIGNER_LIB): src/*.cpp src/*.h
+	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
 	$(CXX) -shared testlib/*.cpp -o testlib.so
 
-test: foreigner.so testlib.so
+test: $(FOREIGNER_LIB) testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,14 @@ ifeq ($(UNAME),Darwin)
 	LIB_SUFFIX := dylib
 	EXTRA_FLAGS := -Og
 	EXTRA_LIBS :=
-else
+else ifeq ($(UNAME),Linux)
 	PLATFORM := linux
 	CXX := g++
 	LIB_SUFFIX := so
 	EXTRA_FLAGS :=
 	EXTRA_LIBS := -lstdc++ -static-libstdc++ -static-libgcc
+else
+$(error Unrecognized platform name.)
 endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 GODOTCPP_PATH ?= ../godot-cpp
 GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
+CROSS_COMPILE_PLATFORM ?=
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@ ifeq ($(UNAME),Darwin)
 	PLATFORM := osx
 	CXX := clang++
 	LIB_SUFFIX := dylib
+	EXTRA_FLAGS := -Og
 else
 	PLATFORM := linux
 	CXX := g++
 	LIB_SUFFIX := so
+	EXTRA_FLAGS :=
 endif
 
 FOREIGNER_LIB := foreigner.$(LIB_SUFFIX)
@@ -26,7 +28,7 @@ INCLUDES= \
 		  $(FFI_INCLUDES)
 
 LIBS = -lgodot-cpp.$(PLATFORM).debug.64 -lstdc++ -lffi -static-libstdc++ -static-libgcc
-FLAGS = -ggdb -fPIC
+FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 
 all: $(FOREIGNER_LIB)
 
@@ -34,7 +36,7 @@ $(FOREIGNER_LIB): src/*.cpp src/*.h
 	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.so: testlib/*.cpp
-	$(CXX) -shared testlib/*.cpp -o testlib.so
+	$(CXX) -shared testlib/*.cpp -o testlib.so $(EXTRA_FLAGS)
 
 test: $(FOREIGNER_LIB) testlib.so
 	$(GODOT_BINARY) --no-window -s test/test.gd

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ GODOT_PATH ?= ../godot
 GODOT_BINARY ?= $(GODOT_PATH)/bin/godot.x11.tools.64
 CROSS_COMPILE_PLATFORM ?=
 
+# Uncomment this for additional linker log output
+# which can be helpful for diagnosing static vs dynamic
+# linking issues.
+#
+#VERBOSE_LINK := -Wl,-v
+
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)
 	PLATFORM := osx
@@ -43,10 +49,10 @@ FLAGS = -ggdb -fPIC $(EXTRA_FLAGS)
 all: $(FOREIGNER_LIB)
 
 $(FOREIGNER_LIB): src/*.cpp src/*.h
-	$(CXX) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
+	$(CXX) $(VERBOSE_LINK) -shared src/*.cpp -o $(FOREIGNER_LIB) $(LIBS) $(INCLUDES) $(FLAGS)
 
 testlib.$(LIB_SUFFIX): testlib/*.cpp
-	$(CXX) -shared testlib/*.cpp -o testlib.$(LIB_SUFFIX) $(EXTRA_FLAGS) $(EXTRA_LIBS)
+	$(CXX) $(VERBOSE_LINK) -shared testlib/*.cpp -o testlib.$(LIB_SUFFIX) $(EXTRA_FLAGS) $(EXTRA_LIBS)
 
 test: $(FOREIGNER_LIB) testlib.$(LIB_SUFFIX)
 	$(GODOT_BINARY) --no-window -s test/test.gd

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ else ifeq ($(UNAME),Linux)
 		BITS := 64
 		CXX := x86_64-w64-mingw32-g++
 		LIB_SUFFIX := dll
+#		EXTRA_FLAGS := -std=c++11 -DFFI_BUILDING
 		EXTRA_FLAGS := -std=c++11
 		EXTRA_LIBS := -static-libstdc++ -static-libgcc
 		PKG_CONFIG_ENV_VARS := PKG_CONFIG_LIBDIR=/usr/x86_64-w64-mingw32/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 PKG_CONFIG_ALLOW_SYSTEM_LIBS=1

--- a/foreigner.gdnlib
+++ b/foreigner.gdnlib
@@ -10,6 +10,7 @@ reloadable=true
 X11.64="res://foreigner.so"
 OSX.64="res://foreigner.dylib"
 Windows.64="res://foreigner.dll"
+Server.64="res://foreigner.so"
 
 [dependencies]
 

--- a/foreigner.gdnlib
+++ b/foreigner.gdnlib
@@ -8,7 +8,9 @@ reloadable=true
 [entry]
 
 X11.64="res://foreigner.so"
+OSX.64="res://foreigner.dylib"
 
 [dependencies]
 
 X11.64=[  ]
+OSX.64=[  ]

--- a/foreigner.gdnlib
+++ b/foreigner.gdnlib
@@ -16,3 +16,4 @@ Server.64="res://foreigner.so"
 
 X11.64=[  ]
 OSX.64=[  ]
+#Windows.64=["/usr/x86_64-w64-mingw32/bin/libffi-7.dll"]

--- a/foreigner.gdnlib
+++ b/foreigner.gdnlib
@@ -9,6 +9,7 @@ reloadable=true
 
 X11.64="res://foreigner.so"
 OSX.64="res://foreigner.dylib"
+Windows.64="res://foreigner.dll"
 
 [dependencies]
 

--- a/src/crossplatform.cpp
+++ b/src/crossplatform.cpp
@@ -1,5 +1,10 @@
 #include "crossplatform.h"
 
+#ifdef IS_WINDOWS
+#include <string>
+std::string error_number_as_string;
+#endif
+
 HANDLE open_library(char *path) {
 #ifdef IS_UNIX
     return dlopen(path, RTLD_LAZY);  // TODO: Is RTLD_LAZY the best?
@@ -8,12 +13,14 @@ HANDLE open_library(char *path) {
 #endif
 }
 
-char* open_library_error() {
+const char *open_library_error() {
 #ifdef IS_UNIX
     return dlerror();
 #else
-    return GetLastError();
-#endif
+    // TODO: Use standard approach to convert GetLastError() to message.
+    error_number_as_string = std::to_string(GetLastError());
+    return error_number_as_string.c_str();
+ #endif
 }
 
 int close_library(HANDLE handle) {

--- a/src/crossplatform.h
+++ b/src/crossplatform.h
@@ -9,7 +9,6 @@ typedef void* HANDLE;
 
 #ifdef _WIN32
 #include <windows.h>
-typedef HINSTANCE HANDLE;
 #define IS_WINDOWS
 #endif
 

--- a/src/crossplatform.h
+++ b/src/crossplatform.h
@@ -17,7 +17,7 @@ typedef void* HANDLE;
 typedef void* SYMBOL;
 
 HANDLE open_library(char *path);
-char* open_library_error();
+const char *open_library_error();
 int close_library(HANDLE handle);
 SYMBOL get_symbol(HANDLE handle, char *symbol);
 

--- a/src/crossplatform.h
+++ b/src/crossplatform.h
@@ -8,7 +8,7 @@ typedef void* HANDLE;
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 typedef HINSTANCE HANDLE;
 #define IS_WINDOWS
 #endif

--- a/src/foreigner.cpp
+++ b/src/foreigner.cpp
@@ -29,7 +29,7 @@ Ref<ForeignLibrary> Foreigner::open(String path) {
     Godot::print("Foreigner: Loading shared library " + path);
     // TODO: Windows/Linux/Mac
     HANDLE handle = open_library(path.alloc_c_string());
-    char *error = open_library_error();
+    const char *error = open_library_error();
     if (error) {
         // Opening failed
         Godot::print_error(

--- a/src/foreigner.cpp
+++ b/src/foreigner.cpp
@@ -29,13 +29,17 @@ Ref<ForeignLibrary> Foreigner::open(String path) {
     Godot::print("Foreigner: Loading shared library " + path);
     // TODO: Windows/Linux/Mac
     HANDLE handle = open_library(path.alloc_c_string());
-    const char *error = open_library_error();
-    if (error) {
-        // Opening failed
-        Godot::print_error(
-                String("Foreigner: Failed to load " + path + ": " + String(error)),
-                __FUNCTION__, __FILE__, __LINE__
-        );
+
+    if (handle==nullptr) {
+        const char *error = open_library_error();
+
+        if (error) {
+            // Opening failed
+            Godot::print_error(
+                    String("Foreigner: Failed to load " + path + ": " + String(error)),
+                    __FUNCTION__, __FILE__, __LINE__
+            );
+        }
         return 0;
     }
 

--- a/src/foreignlibrary.cpp
+++ b/src/foreignlibrary.cpp
@@ -1,5 +1,3 @@
-#include <dlfcn.h>
-
 #include "foreignlibrary.h"
 
 using namespace godot;

--- a/test/test.gd
+++ b/test/test.gd
@@ -12,7 +12,13 @@ func _init():
     ASSERT(foreigner)
     prints('Foreigner:', foreigner)
 
-    var lib = foreigner.open('./testlib.so')
+    var test_lib_filename: String = './testlib.so'
+
+    if OS.get_name() == "Windows":
+        test_lib_filename = './testlib.dll'
+
+    var lib = foreigner.open(test_lib_filename)
+
     ASSERT(lib)
     print('Library:', lib)
 

--- a/testlib/testlib.cpp
+++ b/testlib/testlib.cpp
@@ -13,7 +13,7 @@ extern "C" int32_t sqr(int32_t n) {
 }
 
 extern "C" int32_t add2i(int32_t a, int32_t b) {
-    printf("Called add2i(%d)\n", a, b);
+    printf("Called add2i(%d, %d)\n", a, b);
     return a + b;
 }
 


### PR DESCRIPTION
Adds Windows cross-compiling on Linux support to my earlier Mac build PR (although I still need to verify I didn't break anything in that :) ), also:

 * Fixes an issue where opening would "fail" because the last error value was checked even when the handle was valid.

 * Makes the test script work cross-platform.

I've checked the resulting `.dll` works both on Wine64 & an actual Windows 10 Home machine.

I haven't tested non-cross-compilation building on Windows.

(Oh, yeah, just remembered, `make all` may not work at the moment--I just always use the test target.)

I've tried to document as much as I can, because figuring out the approach for `libffi` in particular took a bunch of research. I've got some more related notes which I may or may not get around to adding. :)

Anyway, it seems to work sufficiently for my purposes currently so I thought I'd at least submit as a draft PR so you know it'd been done. :)